### PR TITLE
Add a failure logging message

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -430,8 +430,8 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 	# Repeat recursion until search space has been exhausted
 	#===============================================================================
 
-	#Total number of "recipies" needed to complete a route, including the Chapter 5 step.
-	TOTAL_RECIPIES_NEEDED = 58
+	#Total number of "recipes" needed to complete a route, including the Chapter 5 step.
+	TOTAL_RECIPES_NEEDED = 58
 	#Total frames to choose an additional ingredient (As opposed to just a single ingredient)
 	#This does not include the additional frames needed to navigate to the items that you want to use
 	CHOOSE_2ND_INGREDIENT_FRAMES = 56
@@ -458,7 +458,7 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 		framesTaken = [0]
 		totalFrames = [0]
 		inventory = [startingInventory]
-		outputCreated = [[False]*TOTAL_RECIPIES_NEEDED]
+		outputCreated = [[False]*TOTAL_RECIPES_NEEDED]
 		legalMoves = []
 		currentFrameRecord = getFastestRecordOnFTP()		
 
@@ -483,7 +483,7 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 				stepIndex -= 1
 
 			#Check for end condition (57 Recipes + the Chapter 5 intermission, which is treated as an additional "recipe")
-			elif(outputCreated[stepIndex].count(True) == TOTAL_RECIPIES_NEEDED):
+			elif(outputCreated[stepIndex].count(True) == TOTAL_RECIPES_NEEDED):
 				#All Recipes have been fulfilled!
 				#Check that the total time taken is strictly less than the current observed record.
 
@@ -522,10 +522,10 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 
 				#Only evaluate the 57th recipe (Mistake) when its the last recipe to fulfill
 				# This is because it is relatively easy to craft this output with many of the previous outputs, and will take minimal frames
-				if(outputCreated[stepIndex].count(True) == TOTAL_RECIPIES_NEEDED - 1):
-					upperOutputLimit = TOTAL_RECIPIES_NEEDED
+				if(outputCreated[stepIndex].count(True) == TOTAL_RECIPES_NEEDED - 1):
+					upperOutputLimit = TOTAL_RECIPES_NEEDED
 				else:
-					upperOutputLimit = TOTAL_RECIPIES_NEEDED - 1
+					upperOutputLimit = TOTAL_RECIPES_NEEDED - 1
 		
 				for outputItem in range(1,upperOutputLimit):
 					#Only want recipes that haven't already been fulfilled
@@ -947,4 +947,4 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 
 		# We've hit max iteration count, but didn't find a result.
 		# Log some information so it's clear we've bailed out.
-		log(3, "Calculator", "Info", "Call " + str(callNumber), "Failed to find result. Made {0} out of {1} recipies in {2} steps for {3} frames.".format(outputCreated[stepIndex].count(True), TOTAL_RECIPIES_NEEDED, stepIndex, totalFrames[stepIndex]))
+		log(3, "Calculator", "Info", "Call " + str(callNumber), "Failed to find result. Made {0} out of {1} recipes in {2} steps for {3} frames.".format(outputCreated[stepIndex].count(True), TOTAL_RECIPES_NEEDED, stepIndex, totalFrames[stepIndex]))

--- a/calculator.py
+++ b/calculator.py
@@ -503,6 +503,8 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 					printResults("results/[{0}].txt".format(totalFrames[stepIndex]),writtenStep,framesTaken,totalFrames,inventory,outputCreated,itemNames,stepIndex)
 
 					return [totalFrames[stepIndex], callNumber]
+
+				log(3, "Calculator", "Info", "Call " + str(callNumber), "Route found, but it's not fast enough. {1} steps in {2} frames is greater than current record of {3}.".format(stepIndex, totalFrames[stepIndex], currentFrameRecord))
 						
 				#Regardless of record status, its time to go back up and find new endstates
 				#Wipe away the current state

--- a/calculator.py
+++ b/calculator.py
@@ -941,14 +941,14 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 						outputCreated[stepIndex + 1][legalMoves[stepIndex][0][1]-1] = True
 
 					stepIndex += 1
-					
+					currentRecipes = outputCreated[stepIndex].count(True)
 				
 					# Track some of our "best" values for more detailed logging.
-					if bestRecipesMade < outputCreated[stepIndex].count(True):
-						bestRecipesMade = max(outputCreated[stepIndex].count(True), bestRecipesMade)
+					if bestRecipesMade < currentRecipes:
+						bestRecipesMade = max(currentRecipes, bestRecipesMade)
 						bestStepIndex = stepIndex
 						bestTotalFrames = totalFrames[stepIndex]
-					elif bestRecipesMade == outputCreated[stepIndex].count(True):
+					elif bestRecipesMade == currentRecipes:
 						bestStepIndex = min(stepIndex, bestStepIndex)
 						bestTotalFrames = min(totalFrames[stepIndex], bestTotalFrames)
 

--- a/calculator.py
+++ b/calculator.py
@@ -430,6 +430,8 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 	# Repeat recursion until search space has been exhausted
 	#===============================================================================
 
+	#Total number of "recipies" needed to complete a route, including the Chapter 5 step.
+	TOTAL_RECIPIES_NEEDED = 58
 	#Total frames to choose an additional ingredient (As opposed to just a single ingredient)
 	#This does not include the additional frames needed to navigate to the items that you want to use
 	CHOOSE_2ND_INGREDIENT_FRAMES = 56
@@ -456,7 +458,7 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 		framesTaken = [0]
 		totalFrames = [0]
 		inventory = [startingInventory]
-		outputCreated = [[False]*58]
+		outputCreated = [[False]*TOTAL_RECIPIES_NEEDED]
 		legalMoves = []
 		currentFrameRecord = getFastestRecordOnFTP()		
 
@@ -481,7 +483,7 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 				stepIndex -= 1
 
 			#Check for end condition (57 Recipes + the Chapter 5 intermission, which is treated as an additional "recipe")
-			elif(outputCreated[stepIndex].count(True) == 58):
+			elif(outputCreated[stepIndex].count(True) == TOTAL_RECIPIES_NEEDED):
 				#All Recipes have been fulfilled!
 				#Check that the total time taken is strictly less than the current observed record.
 
@@ -520,10 +522,10 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 
 				#Only evaluate the 57th recipe (Mistake) when its the last recipe to fulfill
 				# This is because it is relatively easy to craft this output with many of the previous outputs, and will take minimal frames
-				if(outputCreated[stepIndex].count(True) == 57):
-					upperOutputLimit = 58
+				if(outputCreated[stepIndex].count(True) == TOTAL_RECIPIES_NEEDED - 1):
+					upperOutputLimit = TOTAL_RECIPIES_NEEDED
 				else:
-					upperOutputLimit = 57
+					upperOutputLimit = TOTAL_RECIPIES_NEEDED - 1
 		
 				for outputItem in range(1,upperOutputLimit):
 					#Only want recipes that haven't already been fulfilled
@@ -942,3 +944,7 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 						log(4, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000))
 					elif(iterationCount % 1000 == 0):
 						log(6, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000))
+
+		# We've hit max iteration count, but didn't find a result.
+		# Log some information so it's clear we've bailed out.
+		log(3, "Calculator", "Info", "Call " + str(callNumber), "Failed to find result. Made {0} out of {1} recipies in {2} steps for {3} frames.".format(outputCreated[stepIndex].count(True), TOTAL_RECIPIES_NEEDED, stepIndex, totalFrames[stepIndex]))

--- a/calculator.py
+++ b/calculator.py
@@ -452,7 +452,9 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 	#start main loop
 	while(True):
 		stepIndex = 0
-		maxStepIndex = 0
+		bestStepIndex = 0
+		bestRecipesMade = 0
+		bestTotalFrames = 0
 		iterationCount = 0
 		#State Description for each "Step" taken
 		writtenStep = ["Begin"]
@@ -467,7 +469,7 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 
 		#If the iteration count exceeds a given threshold,
 		#Then reset the entire search space and begin anew
-		while(iterationCount < 1000000):
+		while(iterationCount < 500000):
 
 			#Check for bad states to immediately retreat from
 			#The Thunder Rage must remain in the inventory until the Ch.5 Intermission
@@ -903,7 +905,6 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 						outputCreated[stepIndex + 1][legalMoves[stepIndex][0][1]-1] = True
 
 					stepIndex += 1
-					maxStepIndex = max(stepIndex, maxStepIndex)
 			else:
 				#Pop the 1st instance of the list, as it has already been recursed down
 				legalMoves[stepIndex].pop(0)
@@ -940,16 +941,23 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 						outputCreated[stepIndex + 1][legalMoves[stepIndex][0][1]-1] = True
 
 					stepIndex += 1
-					maxStepIndex = max(stepIndex, maxStepIndex)
+					
+					if bestRecipesMade < outputCreated[stepIndex].count(True):
+						bestRecipesMade = max(outputCreated[stepIndex].count(True), bestRecipesMade)
+						bestStepIndex = stepIndex
+						bestTotalFrames = totalFrames[stepIndex]
+					elif bestRecipesMade == outputCreated[stepIndex].count(True):
+						bestStepIndex = min(stepIndex, bestStepIndex)
+						bestTotalFrames = min(totalFrames[stepIndex], bestTotalFrames)
 					#logging for progress display
 					iterationCount += 1
 					if(iterationCount % 500000 == 0):
-						log(3, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Max steps {3}.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, maxStepIndex))
+						log(3, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestTotalFrames, bestStepIndex, bestTotalFrames))
 					elif(iterationCount % 100000 == 0):
-						log(4, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Max steps {3}.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, maxStepIndex))
+						log(4, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestTotalFrames, bestStepIndex, bestTotalFrames))
 					elif(iterationCount % 1000 == 0):
-						log(6, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Max steps {3}.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, maxStepIndex))
+						log(6, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestTotalFrames, bestStepIndex, bestTotalFrames))
 
 		# We've hit max iteration count, but didn't find a result.
 		# Log some information so it's clear we've bailed out.
-		log(3, "Calculator", "Info", "Call " + str(callNumber), "Failed to find result. Made {0} out of {1} recipes in {2} steps for {3} frames.".format(outputCreated[stepIndex].count(True), TOTAL_RECIPES_NEEDED, stepIndex, totalFrames[stepIndex]))
+		log(3, "Calculator", "Info", "Call " + str(callNumber), "Failed to find result. Made {0} out of {1} recipes in {2} steps for {3} frames.".format(bestRecipesMade, TOTAL_RECIPES_NEEDED, bestStepIndex, bestTotalFrames))

--- a/calculator.py
+++ b/calculator.py
@@ -955,11 +955,11 @@ def calculateOrder(callNumber, startingInventory, recipeList, invFrames):
 					#logging for progress display
 					iterationCount += 1
 					if(iterationCount % 500000 == 0):
-						log(3, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestTotalFrames, bestStepIndex, bestTotalFrames))
+						log(3, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestRecipesMade, bestStepIndex, bestTotalFrames))
 					elif(iterationCount % 100000 == 0):
-						log(4, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestTotalFrames, bestStepIndex, bestTotalFrames))
+						log(4, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestRecipesMade, bestStepIndex, bestTotalFrames))
 					elif(iterationCount % 1000 == 0):
-						log(6, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestTotalFrames, bestStepIndex, bestTotalFrames))
+						log(6, "Calculator", "Info", "Call " + str(callNumber), "{0} Steps taken using {1} frames; {2}k iterations. Best is {3} recipies completed in {4} steps and {5} frames.".format(stepIndex, totalFrames[stepIndex], iterationCount / 1000, bestRecipesMade, bestStepIndex, bestTotalFrames))
 
 		# We've hit max iteration count, but didn't find a result.
 		# Log some information so it's clear we've bailed out.


### PR DESCRIPTION
I found running the script for the first time that it wasn't clear that hitting 500k iterations was a _failure_ state for the investigation, and forced a restart. I added a log message for when the loop is restarted, indicating that there was a failure and how "close" it was to success.