### PR TITLE
Major Update: 3.0.0

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -8,11 +8,11 @@
 # Biased towards picking moves near the start #
 # of the list that are typically faster:      #
 #                                             #
-# [select = True ](default: True)             #
+# [select = True](default: True)             #
 #                                             #
 ###############################################
 # Randomise completely shuffles legal moves   #
-# for first 50 moves. Randomise is ignored if #
+# for first 60 moves. Randomise is ignored if #
 # Select is set to 'True'                     #
 #                                             #
 # [randomise = False](default: False)         #
@@ -56,7 +56,7 @@
 # your CPU (depending on how many you need    #
 # for your other activities)                  #
 ###############################################
-# [workerCount = 4] (default: 4)              #
+# [workerCount = 8] (default: 4)              #
 ###############################################
 
 ###############################################
@@ -64,9 +64,9 @@
 ###############################################
 # Your username under which your records are  #
 # Uploaded to the remote server               #
-# [Username = DefaultUser]                    #
+# [Username = Cubik]                    #
 ###############################################
 
 ###############################################
-# [Version = 2.3.4]                           #
+# [Version = 3.0.0]                           #
 ###############################################

--- a/recipes-JP.txt
+++ b/recipes-JP.txt
@@ -390,19 +390,27 @@ Fresh Juice
 Inky Sauce
 Icicle Pop
 Zess Frappe
-Snow Bunny
 Coco Candy
 Honey Candy
 Jelly Candy
 Electro Pop
 Fire Pop
 Space Food
-Poison Shroom
 Trial Stew
 Courage Meal
 Coconut Bomb
 Egg Bomb
 Zess Dynamite
+Courage Shell
+Hot Dog
+Ice Storm
+Mystery
+Ruin Powder
+Shooting Star
+Shroom Fry
+Tasty Tonic
+Thunder Bolt
+Thunder Rage
 ===
 Dried Bouquet
 ---

--- a/start.py
+++ b/start.py
@@ -4,18 +4,20 @@ from inventory import getStartingInventory, getInventoryFrames
 from recipes import getRecipeList
 from config import getConfig
 from logger import log
+from time import sleep
 from FTPManagement import getFastestRecordOnFTP, testRecord, checkForUpdates
 
 def worker(workQueue, doneQueue):
 	while(True):
 		job = workQueue.get(True)
+		sleep(0.1*job[0])
 		#waiting for a job to appear
 		#in this case job refers to a single instance of calculating the recipe order
-		result = calculateOrder(job[0], job[1], job[2], job[3])
+		result = calculateOrder(job[0], job[1], job[2], job[3], job[4])
 		#write the calculated result to the "done" queue
 		doneQueue.put(result, False)
 
-def work(startingInventory, recipeList, invFrames):
+def work(startingInventory, recipeList, invFrames, current_frame_record):
 	#create queues
 	doneQueue = multiprocessing.Queue(workerCount)
 	workQueue = multiprocessing.Queue(workerCount)
@@ -29,7 +31,7 @@ def work(startingInventory, recipeList, invFrames):
 		instances.append(instance)
 	#start jobs
 	for i in range (workerCount):
-		job = [i, startingInventory, recipeList, invFrames]
+		job = [i, startingInventory, recipeList, invFrames, current_frame_record]
 		workQueue.put(job, False)
 	#waiting for first result
 	result = doneQueue.get(True)
@@ -45,14 +47,15 @@ if __name__ == '__main__':
 	recipeList = getRecipeList()
 	invFrames = getInventoryFrames()
 	workerCount = int(getConfig("workerCount"))
+	current_frame_record = 9999
 	while(True):
-		checkForUpdates()
-		currentFrameRecord = getFastestRecordOnFTP()
+		#checkForUpdates()
+		#current_frame_record = getFastestRecordOnFTP()
 		#start the work
-		result = work(startingInventory, recipeList, invFrames)
+		result = work(startingInventory, recipeList, invFrames, current_frame_record)
 		#sanity check
-		if(result[0] < currentFrameRecord):
-			testRecord(result[0])
-			currentFrameRecord = result[0]
-			log(1, "Main", "Results", "", 'cycle {0} done, current record: {1} frames. Record on call {2}.'.format(cycle_count, currentFrameRecord, result[1]))
+		if(result[0] < current_frame_record):
+			#testRecord(result[0])
+			current_frame_record = result[0]
+			log(1, "Main", "Results", "", 'cycle {0} done, current record: {1} frames. Record on call {2}.'.format(cycle_count, current_frame_record, result[1]))
 		cycle_count += 1


### PR DESCRIPTION
- 200 frame buffer added to ongoing search space: In other words, given a current frame record (X), the recursion will search up to (200+X) frames deep before retreating. This is done because:
- OptimizeRoadmap implemented: when the recursion has reached an end state and produced a roadmap (Which might not be a record just yet), it will evaluate all recipes that were performed and see if there isn't an immediately more preferable place where the same output can be prepared. This only works for recipes where the ingredients were duplicated and the output was immediately tossed
- Updated understanding of Auto-placement in "NULL" slots: Before, it was assumed an output item was immediately placed in the first available "NULL" slot of an inventory. It is now understood that all inventory items before the NULL are moved back one position (Ex: slot 1-to-2, slot 2-to-3, etc...) and the output item will always occupy the newly-vacant first slot.
- Logging updates: Default logging will now display how many times a worker has begun searching from a clean slate. Basically gotten rid of the misleading logging that lead some to think they had found better solutions when they were just partial roadmaps.
- Moved some calculator.py constant values into a global scope for now
- Began implementation for a "Personal Best", but commented out the FTP stuff for now
- Added a time.sleep() command for the workers so that they don't simultaneously print log messages